### PR TITLE
Updated echo.js

### DIFF
--- a/_articles/redux_jwt_auth/frontend/src/reducers/echo.js
+++ b/_articles/redux_jwt_auth/frontend/src/reducers/echo.js
@@ -15,4 +15,4 @@ export default (state=initialState, action) => {
   }
 }
 
-export const serverMessage = (state) => state.message
+export const serverMessage = (state) => state.echo.message


### PR DESCRIPTION
was recommended by member in stackoverflow: https://stackoverflow.com/questions/50574659/react-redux-does-not-produce-output-value

comments from expert:  the appState object passed to mapStateToProps, which you are providing to your serverMessage selector function, is not the slice of app state managed by a single reducer. It's the global Redux store state.

you probably want this in reducers/echo.js :

export const serverMessage = (state) => state.echo.message;