### PR TITLE
Fix view name typo in custom_views app.

### DIFF
--- a/custom_views/demo/bloodtest/flows.py
+++ b/custom_views/demo/bloodtest/flows.py
@@ -9,7 +9,7 @@ class BloodTestFlow(Flow):
     process_class = models.BloodTestProcess
 
     first_sample = flow.Start(
-        views.FirstBoodSampleView
+        views.FirstBloodSampleView
     ).Next(this.biochemical_analysis)
 
     second_sample = flow.Start(

--- a/custom_views/demo/bloodtest/views.py
+++ b/custom_views/demo/bloodtest/views.py
@@ -9,7 +9,7 @@ from viewflow.flow.views.utils import get_next_task_url
 from . import forms, models
 
 
-class FirstBoodSampleView(StartFlowMixin, SessionWizardView):
+class FirstBloodSampleView(StartFlowMixin, SessionWizardView):
     template_name = 'bloodtest/bloodtest/first_sample.html'
 
     form_list = [forms.PatientForm, forms.BloodSampleForm]


### PR DESCRIPTION
There was a typo in the view name "FirstBoodSampleView", that's been rectified to "FirstBloodSampleView"